### PR TITLE
Add education section to about-me.txt

### DIFF
--- a/about-me.txt
+++ b/about-me.txt
@@ -2,3 +2,6 @@ My name is Winfred Wangui and I'm Learning Git.
 I love learning new technologies.
 Hobbies: Reading and exploring new healthcare technologies.
 Goals: To merge healthcare with AI and create impactful digital health solutions.
+Education:
+- Studying Software Engineering
+- Passionate about lifelong learning


### PR DESCRIPTION
I added an education section describing my learning background to highlight my learning journey and provide more context about my background. This helps make the file more complete and professional. @bonaventureogeto please review this pull request.